### PR TITLE
delete the pointers owned by the class

### DIFF
--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -262,7 +262,14 @@ Vizkit3DWidget::Vizkit3DWidget( QWidget* parent,int width,int height,const QStri
         _timer.start(10);
 }
 
-Vizkit3DWidget::~Vizkit3DWidget() {}
+Vizkit3DWidget::~Vizkit3DWidget() 
+{
+    delete env_plugin;
+    for(auto& plugin : plugins)
+    {
+        delete plugin.first;
+    }
+}
 
 //qt ruby is crashing if we use none pointer here
 QStringList* Vizkit3DWidget::getVisualizationFramesRuby() const


### PR DESCRIPTION
This was leading to problems when trying to delete the Vizkit3DWidget
object and respawing it again