### PR TITLE
Add method to change the osg::viewer update timeout

### DIFF
--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -1225,3 +1225,8 @@ void Vizkit3DWidget::setCameraManipulator(CAMERA_MANIPULATORS manipulatorType, b
     }
 }
 
+void Vizkit3DWidget::setUpdateTimeout(int msec) {
+    _timer.stop();
+    _timer.start(msec);
+}
+

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -370,6 +370,11 @@ namespace vizkit3d
              */
             void clearEnvironmentPlugin();
 
+            /**
+             * Defines the timeout in milliseconds for updating the osg::viewer
+             */
+            void setUpdateTimeout(int msec);
+
         signals:
             void addPlugins(QObject* plugin,QObject* parent);
             void removePlugins(QObject* plugin);


### PR DESCRIPTION
This PR includes a function to `Vizkit3DWidget` for changing the update timeout of the `osg::viewer`.