### PR TITLE
fix: add osg_qt dependency

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -7,6 +7,7 @@
     <copyright>
 	DFKI/robotik@dfki.de
     </copyright>
+    <depend package="gui/osg_qt4" />
     <depend package="osg" />
     <depend package="qt4" />
     <depend package="qt4-opengl" />


### PR DESCRIPTION
it was removed from rock.core autobuild file in https://github.com/rock-core/package_set/pull/230